### PR TITLE
grand-1 v0.5.0 chain upgrade

### DIFF
--- a/testnet/grand-1/chain-upgrades/v0.4.1/README.md
+++ b/testnet/grand-1/chain-upgrades/v0.4.1/README.md
@@ -61,6 +61,18 @@ f8a0d8942bcf02b94ed875ded9cb23944a53e48a@141.95.97.28:15656
 d82829d886635ffcfcef66adfaa725acb522e1c6@83.136.255.243:26656
 ```
 
+## Endpoints
+RPC: 
+* https://rpc.testnet.noble.strange.love:443  
+
+API:
+* https://api.testnet.noble.strange.love:443  
+
+## Block Explorer  
+https://explore.strange.love  
+https://www.mintscan.io/noble  
+
+
 ## Binary
 
 Docker images are available [here](https://github.com/strangelove-ventures/noble/pkgs/container/noble/72469688?tag=v0.3.0). You can generate the binary by building from the Official Repo. Or alternatively you can use the Verify process below to build inside docker and guarantee you have the correct source.

--- a/testnet/grand-1/chain-upgrades/v0.5.0/README.md
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/README.md
@@ -1,0 +1,100 @@
+# v0.5.0 raydon
+## Description
+This is a proposal to do a software upgrade to the `v0.5.0` software tag of the Noble codebase on block height `637000`, which is estimated to occur on `Tuesday 11th April 17:00 UTC`. Block times have high variance, so please monitor the chain for more precise time estimates.  
+
+ 
+
+## Upgrade Features 
+This upgrade adds the following features:  
+
+### Highlights
+- changeme
+
+### What's Changed
+[changelog](https://github.com/strangelove-ventures/noble/releases/tag/changeme)
+ 
+
+## Getting Prepared for the Upgrade 
+
+https://github.com/strangelove-ventures/noble#build-and-install-to-go-bin-path  
+
+ 
+
+## Details of Upgrade Time 
+The proposal targets the upgrade proposal block to be `637000`, anticipated to be on `Tuesday 11th April 17:00 UTC`. Note that block times have high variance, so keep monitoring the time. See countdown [here](https://testnet.mintscan.io/noble-testnet/blocks/637000).  
+
+The upgrade is anticipated to take approx 30 minutes, during which time, there will not be any on-chain activity on the network.  
+
+In the event of an issue at upgrade time, we should coordinate via the validators channel in telegram to come to a quick emergency consensus and mitigate any further issues.
+
+## Chain Details
+```
+chain-id = "grand-1"
+minimum-gas-prices = "0.0uusdc"
+```
+## Persistent Peers
+```
+#Strangelove
+38179b18853d6a8cb86b99881e02cf72f18b9d0f@34.127.46.223:26656
+57546d799a1cdef74b9a174052821a6e93636dfc@34.145.87.4:26656
+6b76ad22a73897e3c39c7d87b7d12a3b7d690bff@34.168.48.128:26656
+
+#B-Harvest
+f8a0d8942bcf02b94ed875ded9cb23944a53e48a@141.95.97.28:15656
+
+#Everstake
+d82829d886635ffcfcef66adfaa725acb522e1c6@83.136.255.243:26656
+```
+## Endpoints
+RPC: 
+* https://rpc.mainnet.noble.strange.love:443  
+* https://rpc-noble-ia.cosmosia.notional.ventures:443
+
+API:
+* https://api.mainnet.noble.strange.love:443  
+* https://api-noble-ia.cosmosia.notional.ventures:443
+
+## Block Explorer  
+https://explore.strange.love  
+https://www.mintscan.io/noble  
+
+## Binary
+
+Docker images are available [here](https://github.com/strangelove-ventures/noble/pkgs/container/noble/81507034?tag=v0.5.0). You can generate the binary by building from the Official Repo. Or alternatively you can use the Verify process below to build inside docker and guarantee you have the correct source.
+
+```
+git clone https://github.com/strangelove-ventures/noble
+cd noble
+git checkout v0.5.0
+make install
+```
+### Verify Binary Checksum
+Binary checksums can differ based on many things to include go, libc, and make versions. To get a consistent checksum you can use something like docker to verify.
+
+  * [Linux amd64 build](nobled)
+  * Version: `v0.5.0`
+  * SHA256: `184ef72be58dce19e67823f4648c0b522ce282220b4aeb678dc396ae2d3f8675`
+
+  Example of using a volume mount to get the binary outside of the container onto your ubuntu server.
+  ```
+  #run on your ubuntu server
+  # use the `realpath` for the volume mount.
+  docker run -v /home/ubuntu/go/bin:/root/go/bin -it --entrypoint /bin/bash ghcr.io/strangelove-ventures/checksum:v.0.1.0
+  ```
+  ```
+  # run inside docker container.
+  git clone https://github.com/strangelove-ventures/noble.git
+  cd noble
+  git fetch
+  git checkout v0.5.0
+  make install
+  sha256sum ~/go/bin/nobled
+  ```
+  expected return `184ef72be58dce19e67823f4648c0b522ce282220b4aeb678dc396ae2d3f8675`  
+  
+  Now, verify the checksum on your local ubuntu server  
+  ```
+  #run on your ubuntu server
+  sha256sum /home/ubuntu/go/bin/nobled
+  ```
+  expected return `184ef72be58dce19e67823f4648c0b522ce282220b4aeb678dc396ae2d3f8675` 

--- a/testnet/grand-1/chain-upgrades/v0.5.0/README.md
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/README.md
@@ -1,6 +1,6 @@
 # v0.5.0 raydon
 ## Description
-This is a proposal to do a software upgrade to the `v0.5.0` software tag of the Noble codebase on block height `637000`, which is estimated to occur on `Tuesday 11th April 17:00 UTC`. Block times have high variance, so please monitor the chain for more precise time estimates.  
+This is a proposal to do a software upgrade to the `v0.5.0` software tag of the Noble codebase on block height `645000`, which is estimated to occur on `Wednesday 12th April 18:00 UTC`. Block times have high variance, so please monitor the chain for more precise time estimates.  
 
  
 
@@ -11,7 +11,7 @@ This upgrade adds the following features:
 - changeme
 
 ### What's Changed
-[changelog](https://github.com/strangelove-ventures/noble/releases/tag/changeme)
+[changelog](https://github.com/strangelove-ventures/noble/releases/tag/v0.5.0)
  
 
 ## Getting Prepared for the Upgrade 
@@ -21,7 +21,7 @@ https://github.com/strangelove-ventures/noble#build-and-install-to-go-bin-path
  
 
 ## Details of Upgrade Time 
-The proposal targets the upgrade proposal block to be `637000`, anticipated to be on `Tuesday 11th April 17:00 UTC`. Note that block times have high variance, so keep monitoring the time. See countdown [here](https://testnet.mintscan.io/noble-testnet/blocks/637000).  
+The proposal targets the upgrade proposal block to be `645000`, anticipated to be on `Wednesday 12th April 18:00 UTC`. Note that block times have high variance, so keep monitoring the time. See countdown [here](https://testnet.mintscan.io/noble-testnet/blocks/645000).  
 
 The upgrade is anticipated to take approx 30 minutes, during which time, there will not be any on-chain activity on the network.  
 
@@ -58,7 +58,7 @@ https://www.mintscan.io/noble
 
 ## Binary
 
-Docker images are available [here](https://github.com/strangelove-ventures/noble/pkgs/container/noble/81507034?tag=v0.5.0). You can generate the binary by building from the Official Repo. Or alternatively you can use the Verify process below to build inside docker and guarantee you have the correct source.
+Docker images are available [here](https://github.com/strangelove-ventures/noble/pkgs/container/noble/83866075?tag=v0.5.0). You can generate the binary by building from the Official Repo. Or alternatively you can use the Verify process below to build inside docker and guarantee you have the correct source.
 
 ```
 git clone https://github.com/strangelove-ventures/noble
@@ -71,7 +71,7 @@ Binary checksums can differ based on many things to include go, libc, and make v
 
   * [Linux amd64 build](nobled)
   * Version: `v0.5.0`
-  * SHA256: `184ef72be58dce19e67823f4648c0b522ce282220b4aeb678dc396ae2d3f8675`
+  * SHA256: `949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a`
 
   Example of using a volume mount to get the binary outside of the container onto your ubuntu server.
   ```
@@ -88,11 +88,11 @@ Binary checksums can differ based on many things to include go, libc, and make v
   make install
   sha256sum ~/go/bin/nobled
   ```
-  expected return `184ef72be58dce19e67823f4648c0b522ce282220b4aeb678dc396ae2d3f8675`  
+  expected return `949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a`  
   
   Now, verify the checksum on your local ubuntu server  
   ```
   #run on your ubuntu server
   sha256sum /home/ubuntu/go/bin/nobled
   ```
-  expected return `184ef72be58dce19e67823f4648c0b522ce282220b4aeb678dc396ae2d3f8675` 
+  expected return `949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a` 

--- a/testnet/grand-1/chain-upgrades/v0.5.0/README.md
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/README.md
@@ -47,12 +47,10 @@ d82829d886635ffcfcef66adfaa725acb522e1c6@83.136.255.243:26656
 ```
 ## Endpoints
 RPC: 
-* https://rpc.mainnet.noble.strange.love:443  
-* https://rpc-noble-ia.cosmosia.notional.ventures:443
+* https://rpc.testnet.noble.strange.love:443  
 
 API:
-* https://api.mainnet.noble.strange.love:443  
-* https://api-noble-ia.cosmosia.notional.ventures:443
+* https://api.testnet.noble.strange.love:443  
 
 ## Block Explorer  
 https://explore.strange.love  

--- a/testnet/grand-1/chain-upgrades/v0.5.0/checklist.md
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/checklist.md
@@ -1,0 +1,10 @@
+### v0.5.0 readiness check
+
+- [ ] nobled v0.5.0 released
+- [ ] nothing with `changeme` in readmd
+- [ ] build amd64 and arm64 and update cosmovisor plan checksums
+- [ ] add plan to `--upgrade-info`
+- [ ] publish noble binary to noble-networks, and noble release
+- [ ] ensure tags of v0.5.0 and raydon exist
+- [ ] announce upgrade
+- [ ] sign upgrade-software transaction

--- a/testnet/grand-1/chain-upgrades/v0.5.0/plan.json
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/plan.json
@@ -1,7 +1,6 @@
 {
   "binaries": {
-    "linux/amd64": "https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-amd64?checksum=sha256:changeme",
-    "linux/arm64": "https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-arm64?checksum=sha256:changeme"
+    "linux/amd64": "https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-amd64?checksum=sha256:949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a"
   },
   "urls": {
     "docs": "https://github.com/strangelove-ventures/noble-networks/blob/main/testnet/grand-1/chain-upgrades/v0.5.0/README.md"

--- a/testnet/grand-1/chain-upgrades/v0.5.0/plan.json
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/plan.json
@@ -1,8 +1,1 @@
-{
-  "binaries": {
-    "linux/amd64": "https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-amd64?checksum=sha256:949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a"
-  },
-  "urls": {
-    "docs": "https://github.com/strangelove-ventures/noble-networks/blob/main/testnet/grand-1/chain-upgrades/v0.5.0/README.md"
-  }
-}
+{"binaries":{"linux/amd64":"https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-amd64?checksum=sha256:949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a"},"urls":{"docs":"https://github.com/strangelove-ventures/noble-networks/blob/main/testnet/grand-1/chain-upgrades/v0.5.0/README.md"}}

--- a/testnet/grand-1/chain-upgrades/v0.5.0/plan.json
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/plan.json
@@ -1,0 +1,9 @@
+{
+  "binaries": {
+    "linux/amd64": "https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-amd64?checksum=sha256:changeme",
+    "linux/arm64": "https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-arm64?checksum=sha256:changeme"
+  },
+  "urls": {
+    "docs": "https://github.com/strangelove-ventures/noble-networks/blob/main/testnet/grand-1/chain-upgrades/v0.5.0/README.md"
+  }
+}

--- a/testnet/grand-1/chain-upgrades/v0.5.0/upgrade.sh
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/upgrade.sh
@@ -3,5 +3,4 @@ nobled tx upgrade software-upgrade \
 'raydon' \
 --upgrade-height 645000 \
 --upgrade-info '{"binaries":{"linux/amd64":"https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-amd64?checksum=sha256:949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a"},"urls":{"docs":"https://github.com/strangelove-ventures/noble-networks/blob/main/testnet/grand-1/chain-upgrades/v0.5.0/README.md"}}' \
---from noble10uu75g7zl0gnzt0wz46htgqnl5ml27dnthcztx \
---generate-only > raydon-upgrade-unsigned.json
+--from noble10uu75g7zl0gnzt0wz46htgqnl5ml27dnthcztx

--- a/testnet/grand-1/chain-upgrades/v0.5.0/upgrade.sh
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/upgrade.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 nobled tx upgrade software-upgrade \
 'raydon' \
---upgrade-height 119000 \
---upgrade-info 'https://github.com/strangelove-ventures/noble-networks/blob/main/mainnet/noble-1/chain-upgrades/v2.0.0/README.md' \
+--upgrade-height 645000 \
+--upgrade-info '{"binaries":{"linux/amd64":"https://github.com/strangelove-ventures/noble/releases/download/v0.5.0/nobled-v0.5.0-linux-amd64?checksum=sha256:949e84d7600f8520d4eecfd2aa67c81f6b25a3c48f8a66fdc58ba1ee19f9c91a"},"urls":{"docs":"https://github.com/strangelove-ventures/noble-networks/blob/main/testnet/grand-1/chain-upgrades/v0.5.0/README.md"}}' \
 --from noble10uu75g7zl0gnzt0wz46htgqnl5ml27dnthcztx \
 --generate-only > raydon-upgrade-unsigned.json

--- a/testnet/grand-1/chain-upgrades/v0.5.0/upgrade.sh
+++ b/testnet/grand-1/chain-upgrades/v0.5.0/upgrade.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+nobled tx upgrade software-upgrade \
+'raydon' \
+--upgrade-height 119000 \
+--upgrade-info 'https://github.com/strangelove-ventures/noble-networks/blob/main/mainnet/noble-1/chain-upgrades/v2.0.0/README.md' \
+--from noble10uu75g7zl0gnzt0wz46htgqnl5ml27dnthcztx \
+--generate-only > raydon-upgrade-unsigned.json


### PR DESCRIPTION
### v0.5.0 readiness check

- [x] nobled v0.5.0 released
- [x] nothing with `changeme` in readmd
- [x] build amd64  and update cosmovisor plan checksums
- [x] add plan to `--upgrade-info`
- [x] publish noble binary to noble-networks, and noble release
- [x] ensure tags of v0.5.0
- [ ] announce upgrade
- [ ] sign upgrade-software transaction